### PR TITLE
Fix versioneer compat with py312

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,8 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
-    with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+    parser = configparser.ConfigParser()
+    parser.read(setup_cfg)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
SafeConfigParser has been deprecated since Python 3.2 and will be removed in py312.

https://github.com/python/cpython/pull/28292
https://bugs.python.org/issue45173
https://github.com/python/cpython/issues/89336